### PR TITLE
Fix warnings in example project

### DIFF
--- a/Project/addons/state_bot/state_bot.gd
+++ b/Project/addons/state_bot/state_bot.gd
@@ -49,7 +49,7 @@ var current_state: SimpleState = null:
 		# Do nothing if the current and new states are the same.
 		if current_state == new_state:
 			if debug_mode:
-				var debug_reference: String = str(puppet) if puppet else str(self)
+				var debug_reference: String = str(puppet) if is_instance_valid(puppet) else str(self)
 				
 				print_rich("[color=c375f0]SB:[/color] (%s) tried to switch to the current state [b]%s[/b]" \
 				% [debug_reference, current_state.name], ", so nothing happened.")
@@ -59,7 +59,7 @@ var current_state: SimpleState = null:
 		
 		# Send a debug message if debug mode is enabled.
 		if debug_mode:
-			var debug_reference: String = str(puppet) if puppet else str(self)
+			var debug_reference: String = str(puppet) if is_instance_valid(puppet) else str(self)
 			
 			if old_state:
 				print_rich("[color=c375f0]SB:[/color] (%s) state: [b]%s[/b] → [b]%s[/b]" % [debug_reference, old_state.name, new_state.name])
@@ -84,7 +84,8 @@ var current_state: SimpleState = null:
 			deactivated.emit()
 			return
 
-## Cached version of all states. 
+## Cached version of all [SimpleState]s managed by this [StateBot].
+## This variable is updated every time a [SimpleState] descendant enters or exits the tree.
 var all_states: Array[SimpleState]
 
 

--- a/Project/examples/2d_platformer/states/state_airborne.gd
+++ b/Project/examples/2d_platformer/states/state_airborne.gd
@@ -9,17 +9,17 @@ extends SimpleState
 
 
 ## Called once automatically when this state is entered.
-func _enter_state(last_state: SimpleState) -> void:
+func _enter_state(_last_state: SimpleState) -> void:
 	handle_animations()
 
 
 ## Called once automatically when this state is exited.
-func _exit_state(new_state: SimpleState) -> void:
+func _exit_state(_new_state: SimpleState) -> void:
 	pass
 
 
 ## Called every frame while this state is active.
-func _state_process(delta: float) -> void:
+func _state_process(_delta: float) -> void:
 	pass
 
 

--- a/Project/examples/2d_platformer/states/state_idle.gd
+++ b/Project/examples/2d_platformer/states/state_idle.gd
@@ -7,16 +7,16 @@ extends SimpleState
 @onready var animated_sprite: AnimatedSprite2D = %AnimatedSprite2D
 
 ## Called once automatically when this state is entered.
-func _enter_state(last_state: SimpleState) -> void:
+func _enter_state(_last_state: SimpleState) -> void:
 	animated_sprite.play("idle")
 
 ## Called once automatically when this state is exited.
-func _exit_state(new_state: SimpleState) -> void:
+func _exit_state(_new_state: SimpleState) -> void:
 	pass
 
 
 ## Called every frame while this state is active.
-func _state_process(delta: float) -> void:
+func _state_process(_delta: float) -> void:
 	pass
 
 ## Called every physics tick while this state is active.

--- a/Project/examples/2d_platformer/states/state_running.gd
+++ b/Project/examples/2d_platformer/states/state_running.gd
@@ -3,23 +3,22 @@ extends SimpleState
 
 @export var run_speed: float = 150
 @export var run_acceleration: float = 15
-@export var jump_height: float = -400
 
 @onready var player: ExamplePlayer = get_bot().puppet
 @onready var animated_sprite: AnimatedSprite2D = %AnimatedSprite2D
 
 ## Called once automatically when this state is entered.
-func _enter_state(last_state: SimpleState) -> void:
+func _enter_state(_last_state: SimpleState) -> void:
 	animated_sprite.play("running")
 
 
 ## Called once automatically when this state is exited.
-func _exit_state(new_state: SimpleState) -> void:
+func _exit_state(_new_state: SimpleState) -> void:
 	pass
 
 
 ## Called every frame while this state is active.
-func _state_process(delta: float) -> void:
+func _state_process(_delta: float) -> void:
 	pass
 
 
@@ -49,7 +48,7 @@ func handle_movement():
 
 func handle_jumping():
 	if Input.is_action_just_pressed("ui_up"):
-		player.velocity.y = jump_height
+		player.velocity.y = player.jump_height
 		state_bot.switch_to_state("Airborne")
 	
 	if not player.is_on_floor():

--- a/Project/examples/2d_platformer/states/state_wall_jump.gd
+++ b/Project/examples/2d_platformer/states/state_wall_jump.gd
@@ -9,7 +9,7 @@ extends SimpleState
 var wall_normal: float
 
 ## Called once automatically when this state is entered.
-func _enter_state(last_state: SimpleState) -> void:
+func _enter_state(_last_state: SimpleState) -> void:
 	animated_sprite.play("wall_jump")
 	
 	# Check if you hit the wall is on your left (1) or right (-1)
@@ -22,12 +22,12 @@ func _enter_state(last_state: SimpleState) -> void:
 
 
 ## Called once automatically when this state is exited.
-func _exit_state(new_state: SimpleState) -> void:
+func _exit_state(_new_state: SimpleState) -> void:
 	pass
 
 
 ## Called every frame while this state is active.
-func _state_process(delta: float) -> void:
+func _state_process(_delta: float) -> void:
 	pass
 
 


### PR DESCRIPTION
Forgot to include this in the last PR, sorry :sweat_smile:. This should fix any warnings Godot was complaining about about unused variables.